### PR TITLE
fixing CMAKE cross compile flags

### DIFF
--- a/extra_build_script.py
+++ b/extra_build_script.py
@@ -70,8 +70,7 @@ cmake_args = [
     "-B", str(libtropic_build_dir),
     f"-DCMAKE_C_FLAGS={c_flags}",
     f"-DCMAKE_CXX_FLAGS={cxx_flags}",
-    "-DCMAKE_SYSTEM_NAME=Generic",
-    "-DCMAKE_OSX_ARCHITECTURES="
+    "-DCMAKE_SYSTEM_NAME=Generic"
 ]
 
 # Add linker flags only if not on macOS (nosys.specs is specific to ARM GCC)


### PR DESCRIPTION
This is fixing the cross compilation issues with CLANG on MacOSX 15.7.2 (24G325).