### PR TITLE
Review: Mac and destroy

### DIFF
--- a/examples/MAC_and_destroy/MAC_and_destroy.ino
+++ b/examples/MAC_and_destroy/MAC_and_destroy.ino
@@ -67,7 +67,7 @@
 #define PIN_SIZE_MAX 8
 
 // Generate random master secret. When used in production, make sure you generate
-// masterSecret with a secure random generator.
+// myMasterSecret with a secure random generator.
 #define MY_MASTER_SECRET_SIZE 32u
 
 uint8_t myMasterSecret[MY_MASTER_SECRET_SIZE]


### PR DESCRIPTION
Changes:
- clang-format (that's why the diff is so big),
- minor corrections in comments,
- better logging on errors,
- use `sizeof()` where applicable to increase safety and readability,
- moved example body into `loop()` to distinguish between setup and the main example code.